### PR TITLE
fix: localize help slug

### DIFF
--- a/class-terraso.php
+++ b/class-terraso.php
@@ -125,9 +125,9 @@ class Terraso {
 	 */
 	public static function help_rewrite() {
 		add_rewrite_rule( '^help$', 'index.php?help=help', 'top' );
-		add_rewrite_rule( '^ayuda$', 'index.php?help=ayuda', 'top' ); // es
-		add_rewrite_rule( '^aide$', 'index.php?help=aide', 'top' );   // fr
-		add_rewrite_rule( '^ajuda$', 'index.php?help=ajuda', 'top' ); // pt
+		add_rewrite_rule( '^ayuda$', 'index.php?help=ayuda', 'top' ); // es.
+		add_rewrite_rule( '^aide$', 'index.php?help=aide', 'top' );   // fr.
+		add_rewrite_rule( '^ajuda$', 'index.php?help=ajuda', 'top' ); // pt.
 	}
 
 	/**

--- a/class-terraso.php
+++ b/class-terraso.php
@@ -125,7 +125,9 @@ class Terraso {
 	 */
 	public static function help_rewrite() {
 		add_rewrite_rule( '^help$', 'index.php?help=help', 'top' );
-		add_rewrite_rule( '^ayuda$', 'index.php?help=ayuda', 'top' );
+		add_rewrite_rule( '^ayuda$', 'index.php?help=ayuda', 'top' ); // es
+		add_rewrite_rule( '^aide$', 'index.php?help=aide', 'top' );   // fr
+		add_rewrite_rule( '^ajuda$', 'index.php?help=ajuda', 'top' ); // pt
 	}
 
 	/**

--- a/includes/class-terraso-help-cpt.php
+++ b/includes/class-terraso-help-cpt.php
@@ -34,7 +34,7 @@ class Terraso_Help_CPT {
 			'fr_FR' => 'aide',
 			'pt_PT' => 'ajuda',
 		];
-		$slug = $slug_map[ $language ] ?: 'help';
+		$slug     = $slug_map[ $language ] ?: 'help';
 
 		$args = [
 			'label'                 => esc_html__( 'Help pages', 'terraso' ),

--- a/includes/class-terraso-help-cpt.php
+++ b/includes/class-terraso-help-cpt.php
@@ -27,6 +27,15 @@ class Terraso_Help_CPT {
 			'singular_name' => esc_html__( 'Help page', 'terraso' ),
 		];
 
+		$language = get_option( 'WPLANG' ) ?: 'en_US';
+		$slug_map = [
+			'en_US' => 'help',
+			'es_ES' => 'ayuda',
+			'fr_FR' => 'aide',
+			'pt_PT' => 'ajuda',
+		];
+		$slug = $slug_map[ $language ] ?: 'help';
+
 		$args = [
 			'label'                 => esc_html__( 'Help pages', 'terraso' ),
 			'labels'                => $labels,
@@ -48,7 +57,7 @@ class Terraso_Help_CPT {
 			'hierarchical'          => false,
 			'can_export'            => false,
 			'rewrite'               => [
-				'slug'       => 'help',
+				'slug'       => $slug,
 				'with_front' => true,
 			],
 			'query_var'             => true,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,6 +8,7 @@
 
 	<rule ref="WordPress">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
 	</rule>
 
 	<rule ref="WordPressVIPMinimum">


### PR DESCRIPTION
## Description
Localize the help CPT slug. Supports en / es / fr / pt.